### PR TITLE
Fix path alias for hooks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/hooks/*": ["./hooks/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- update tsconfig alias so that '@/hooks/*' resolves to `hooks/*`

## Testing
- `pnpm build`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68528487601c8322b6fee039d536cf07