### PR TITLE
Add env example and setup info

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and replace with your credentials
+
+# Gmail app password used in src/app/api/contact/route.ts
+GMAIL_APP_PASSWORD=your_app_password_here

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# MARU Project
+
+This repository contains the source code for the MARU project built with Next.js.
+
+## Setup
+
+1. Install dependencies using **pnpm**:
+   ```bash
+   pnpm install
+   ```
+2. Copy `.env.example` to `.env` and fill in the required values:
+   ```bash
+   cp .env.example .env
+   ```
+   Update `GMAIL_APP_PASSWORD` with the Gmail application password used for sending contact form emails.
+
+3. Start the development server:
+   ```bash
+   pnpm dev
+   ```


### PR DESCRIPTION
## Summary
- provide `.env.example` with a placeholder for GMAIL_APP_PASSWORD
- document setup steps in README

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6852862794708322b8def4334e8a7400