### PR TITLE
Adjust mobile nav overlay

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -46,7 +46,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMenuOpen && (
-        <div className="md:hidden bg-black border-t border-zinc-800">
+        <div className="md:hidden fixed inset-x-0 top-16 bottom-0 z-40 bg-black border-t border-zinc-800 overflow-y-auto">
           <nav className="flex flex-col py-4 px-4">
             <Link
               href="/"


### PR DESCRIPTION
## Summary
- resize mobile navigation overlay to run from below header to bottom of screen
- keep overlay scrollable when menu items overflow

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68528d9b7c9c8322bffe7dcc59dfb60f