### PR TITLE
Use environment variable for metadata base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 
 # Gmail app password used in src/app/api/contact/route.ts
 GMAIL_APP_PASSWORD=your_app_password_here
+
+# Base URL of the site used for metadata.
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository contains the source code for the MARU project built with Next.js
    ```bash
    cp .env.example .env
    ```
-   Update `GMAIL_APP_PASSWORD` with the Gmail application password used for sending contact form emails.
+   - Update `GMAIL_APP_PASSWORD` with the Gmail application password used for sending contact form emails.
+   - Set `NEXT_PUBLIC_SITE_URL` to your site's public URL. If omitted, `http://localhost:3000` is used in development.
 
 3. Start the development server:
    ```bash

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,9 @@ import React from "react";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('http://localhost:3000'),
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  ),
   title: {
     default: "MARU",
     template: "MARU",


### PR DESCRIPTION
## Summary
- reference `NEXT_PUBLIC_SITE_URL` for `metadataBase`
- document `NEXT_PUBLIC_SITE_URL` usage in README
- add `NEXT_PUBLIC_SITE_URL` to `.env.example`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68528da758548322ae0a67088d0fcbd0