### PR TITLE
Add English pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 
 # Gmail app password used in src/app/api/contact/route.ts
 GMAIL_APP_PASSWORD=your_app_password_here
+
+# Email account used by the contact form API
+CONTACT_EMAIL=your_email_here

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: Request) {
     const transporter = nodemailer.createTransport({
       service: 'gmail',
       auth: {
-        user: 'maruoka@sally-inc.jp',
+        user: process.env.CONTACT_EMAIL,
         // 注意: ここにはGmailのアプリパスワードを設定する必要があります
         pass: process.env.GMAIL_APP_PASSWORD,
       },
@@ -24,8 +24,8 @@ export async function POST(request: Request) {
 
     // メールの内容を設定
     const mailOptions = {
-      from: 'maruoka@sally-inc.jp',
-      to: 'maruoka@sally-inc.jp',
+      from: process.env.CONTACT_EMAIL,
+      to: process.env.CONTACT_EMAIL,
       subject: `[お問い合わせ] ${subject}`,
       text: `
 名前: ${name}

--- a/src/app/en/about/page.tsx
+++ b/src/app/en/about/page.tsx
@@ -1,0 +1,65 @@
+export const metadata = {
+  title: 'About MARU'
+}
+
+export default function EnglishAbout() {
+  return (
+    <div className="pt-16 min-h-screen bg-black">
+      <section className="py-16 bg-zinc-800">
+        <div className="container mx-auto px-4 text-center">
+          <h1 className="text-4xl font-bold mb-4 text-white">Profile</h1>
+          <p className="text-zinc-300 max-w-2xl mx-auto">
+            Learn more about MARU, the creator of murder mystery scenarios.
+          </p>
+        </div>
+      </section>
+      <section className="py-16 bg-zinc-900">
+        <div className="container mx-auto px-4">
+          <div className="max-w-4xl mx-auto bg-zinc-800 p-8 rounded-lg shadow-md">
+            <div className="flex flex-col md:flex-row gap-8 items-center md:items-start mb-8">
+              <div className="w-32 h-32 relative overflow-hidden rounded-full bg-white">
+                <img src="/images/maru-icon.png" alt="MARU" className="object-contain" />
+              </div>
+              <div>
+                <h2 className="text-3xl font-bold mb-2 text-white">MARU</h2>
+                <p className="text-gray-300 mb-4">Murder mystery writer</p>
+                <div className="flex items-center">
+                  <a
+                    href="https://x.com/mok4shiro"
+                    target="_blank"
+                    className="flex items-center text-gray-300 hover:text-white transition-colors"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="mr-2"
+                    >
+                      <path d="M4 4l11.733 16h4.267l-11.733 -16z" />
+                      <path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772" />
+                    </svg>
+                    @mok4shiro
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div className="text-zinc-300 space-y-4">
+              <p>
+                MARU publishes works on the UZU app, focusing on immersive worlds and unique gameplay.
+              </p>
+              <p>
+                Known for titles like "SHADOW CODE" and "JILVAIN".
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/en/contact/page.tsx
+++ b/src/app/en/contact/page.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+
+const works = [
+  { id: 'shadowcode', title: 'SHADOW CODE' },
+  { id: 'sokusekiho', title: 'Instant HO' }
+]
+
+export default function EnglishContact() {
+  const initialState: Record<string, string> = {
+    "entry.1473372340": "",
+    "entry.330209799": "",
+    "entry.1337542843": "",
+    "entry.695875724": "",
+    "entry.643649289": "",
+    "entry.530101119": "",
+  }
+
+  const [formState, setFormState] = useState<Record<string, string>>(initialState)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [error, setError] = useState("")
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target
+    setFormState(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleSelectChange = (value: string, fieldName: string) => {
+    setFormState(prev => ({ ...prev, [fieldName]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError("")
+    try {
+      const formData = new URLSearchParams(formState)
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: formData.toString(),
+      })
+      if (response.status < 200 || response.status > 302) {
+        throw new Error('Failed to send')
+      }
+      setIsSubmitted(true)
+      setFormState(initialState)
+    } catch (error) {
+      console.error('Error submitting form:', error)
+      setError('Failed to send. Please try again later.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="pt-16 min-h-screen bg-black">
+      <section className="py-16 bg-zinc-800">
+        <div className="container mx-auto px-4 text-center">
+          <h1 className="text-4xl font-bold mb-4 text-white">Contact</h1>
+          <p className="text-zinc-300 max-w-2xl mx-auto">
+            Send us a message using the form below.
+          </p>
+        </div>
+      </section>
+      <section className="py-16 bg-zinc-900">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+            <Card className="bg-zinc-800 border-zinc-700 shadow-md">
+              <CardHeader className="border-b border-zinc-700">
+                <CardTitle className="text-white">Contact Form</CardTitle>
+                <CardDescription className="text-zinc-400">Please fill out the form.</CardDescription>
+              </CardHeader>
+              <CardContent className="pt-6">
+                {isSubmitted ? (
+                  <div className="text-center py-8">
+                    <h3 className="text-xl font-bold mb-2 text-white">Thank you</h3>
+                    <p className="text-zinc-300 mb-4">We will reply soon.</p>
+                    <Button variant="outline" onClick={() => setIsSubmitted(false)} className="border-zinc-600 text-white hover:bg-zinc-700">
+                      New message
+                    </Button>
+                  </div>
+                ) : (
+                  <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="grid gap-2">
+                      <Label htmlFor="name" className="text-white">Name</Label>
+                      <Input id="name" name="entry.1473372340" value={formState["entry.1473372340"]} onChange={handleChange} required className="bg-zinc-700 border-zinc-600 text-white" />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="email" className="text-white">Email</Label>
+                      <Input id="email" name="entry.330209799" type="email" value={formState["entry.330209799"]} onChange={handleChange} required className="bg-zinc-700 border-zinc-600 text-white" />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="category" className="text-white">Category</Label>
+                      <Select value={formState["entry.1337542843"]} onValueChange={value => handleSelectChange(value, "entry.1337542843") } required>
+                        <SelectTrigger className="bg-zinc-700 border-zinc-600 text-white">
+                          <SelectValue placeholder="Select a category" />
+                        </SelectTrigger>
+                        <SelectContent className="bg-zinc-700 border-zinc-600">
+                          <SelectItem value="general" className="text-white">Porting request</SelectItem>
+                          <SelectItem value="gm" className="text-white">GM request</SelectItem>
+                          <SelectItem value="collaboration" className="text-white">Collaboration</SelectItem>
+                          <SelectItem value="feedback" className="text-white">Feedback</SelectItem>
+                          <SelectItem value="bugreport" className="text-white">Bug report</SelectItem>
+                          <SelectItem value="other" className="text-white">Other</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {(formState["entry.1337542843"] == "feedback" || formState["entry.1337542843"] == "bugreport") && (
+                      <div className="grid gap-2">
+                        <Label htmlFor="selectedWork" className="text-white">Work</Label>
+                        <Select value={formState["entry.695875724"]} onValueChange={value => handleSelectChange(value, "entry.695875724") } required>
+                          <SelectTrigger className="bg-zinc-700 border-zinc-600 text-white">
+                            <SelectValue placeholder="Select work" />
+                          </SelectTrigger>
+                          <SelectContent className="bg-zinc-700 border-zinc-600">
+                            {works.map(w => (
+                              <SelectItem key={w.id} value={w.id} className="text-white">
+                                {w.title}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+                    <div className="grid gap-2">
+                      <Label htmlFor="subject" className="text-white">Subject</Label>
+                      <Input id="subject" name="entry.643649289" value={formState["entry.643649289"]} onChange={handleChange} required className="bg-zinc-700 border-zinc-600 text-white" />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="message" className="text-white">Message</Label>
+                      <Textarea id="message" name="entry.530101119" rows={5} value={formState["entry.530101119"]} onChange={handleChange} required className="bg-zinc-700 border-zinc-600 text-white" />
+                    </div>
+                    {error && <div className="text-red-500 text-sm">{error}</div>}
+                    <Button type="submit" className="w-full bg-cyan-700 hover:bg-cyan-800 text-white" disabled={isSubmitting}>
+                      {isSubmitting ? 'Sending…' : 'Send'}
+                    </Button>
+                  </form>
+                )}
+              </CardContent>
+            </Card>
+            <div>
+              <Card className="bg-zinc-800 border-zinc-700 shadow-md mb-6">
+                <CardHeader className="border-b border-zinc-700">
+                  <CardTitle className="text-white">Contact</CardTitle>
+                </CardHeader>
+                <CardContent className="pt-6">
+                  <div className="space-y-4">
+                    <div>
+                      <h3 className="font-semibold mb-1 text-white">X</h3>
+                      <a href="https://x.com/mok4shiro" target="_blank" rel="noopener noreferrer" className="flex items-center text-cyan-400 hover:text-white">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
+                          <path d="M4 4l11.733 16h4.267l-11.733 -16z" />
+                          <path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772" />
+                        </svg>
+                        @mok4shiro
+                      </a>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/en/news/page.tsx
+++ b/src/app/en/news/page.tsx
@@ -1,0 +1,43 @@
+export const metadata = { title: 'News - MARU' }
+
+interface NewsItem {
+  title: string
+  description: string
+  date: string
+}
+
+const newsItems: NewsItem[] = [
+  {
+    title: 'Hanagara no Ori coming this summer',
+    description: 'The newest scenario will be released soon.',
+    date: 'Summer 2025'
+  }
+]
+
+export default function EnglishNews() {
+  return (
+    <div className="pt-16 min-h-screen bg-black">
+      <section className="py-16 bg-zinc-800">
+        <div className="container mx-auto px-4 text-center">
+          <h1 className="text-4xl font-bold mb-4 text-white">News</h1>
+          <p className="text-zinc-300 max-w-2xl mx-auto">
+            Latest updates from MARU.
+          </p>
+        </div>
+      </section>
+      <section className="py-16 bg-zinc-900">
+        <div className="container mx-auto px-4">
+          <div className="space-y-8 max-w-3xl mx-auto">
+            {newsItems.map(item => (
+              <article key={item.title} className="bg-zinc-800 p-6 rounded-lg border border-zinc-700">
+                <h2 className="text-2xl font-bold mb-2 text-white">{item.title}</h2>
+                <p className="text-zinc-300 mb-2">{item.description}</p>
+                <p className="text-gray-400 text-sm">{item.date}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -22,7 +22,7 @@ export default function EnglishHome() {
             The latest work, <strong>Hanagara no Ori</strong>, will be released soon.
           </p>
           <p>
-            For inquiries in English, please email <span className="underline">maruoka@sally-inc.jp</span>.
+            For inquiries in English, please use the contact form.
           </p>
         </div>
       </section>

--- a/src/app/en/works/page.tsx
+++ b/src/app/en/works/page.tsx
@@ -1,0 +1,57 @@
+export const metadata = {
+  title: 'Works - MARU'
+}
+
+import Link from 'next/link'
+import Image from 'next/image'
+import { ChevronRight, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+export default function EnglishWorks() {
+  return (
+    <div className="pt-16 min-h-screen bg-black">
+      <section className="py-16 bg-zinc-800">
+        <div className="container mx-auto px-4 text-center">
+          <h1 className="text-4xl font-bold mb-4 text-white">Works</h1>
+          <p className="text-zinc-300 max-w-2xl mx-auto">
+            A selection of scenarios available on the UZU app.
+          </p>
+        </div>
+      </section>
+      <section className="py-16 bg-zinc-900">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <Card className="bg-zinc-800 border-zinc-700 overflow-hidden shadow-md">
+              <div className="relative aspect-video w-full overflow-hidden">
+                <Image src="/images/shadow-code-cover.png" alt="SHADOW CODE" fill className="object-cover" sizes="(max-width: 768px) 100vw, 50vw" />
+                <div className="absolute inset-0 flex items-end">
+                  <div className="bg-black/80 backdrop-blur-sm w-full p-3">
+                    <h3 className="text-2xl font-bold text-white">SHADOW CODE</h3>
+                  </div>
+                </div>
+              </div>
+              <CardContent className="p-6">
+                <p className="text-gray-300 text-sm mb-4">Released: 2024/08/17</p>
+                <div className="flex justify-between items-center">
+                  <Button asChild className="bg-zinc-700 hover:bg-zinc-600 text-white border border-zinc-600">
+                    <Link href="https://www.uzu-app.com/ja/scenario/5808" target="_blank" className="flex items-center">
+                      Play on UZU
+                      <ExternalLink className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                  <Button asChild variant="ghost" className="text-white hover:text-gray-300 p-0">
+                    <Link href="/en/works/shadow-code" className="flex items-center">
+                      Details
+                      <ChevronRight className="h-4 w-4 ml-1" />
+                    </Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,43 +1,47 @@
 import Link from 'next/link'
 import Image from 'next/image'
+import { usePathname } from 'next/navigation'
 
 const Footer = () => {
+  const pathname = usePathname()
+  const isEnglish = pathname.startsWith('/en')
+  const base = isEnglish ? '/en' : ''
   return (
     <footer className="bg-black/90 text-white py-12 mt-auto">
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Links Section */}
           <div>
-            <h3 className="text-xl font-bold mb-4">リンク</h3>
+          <h3 className="text-xl font-bold mb-4">{isEnglish ? 'Links' : 'リンク'}</h3>
             <ul className="space-y-2">
               <li>
-                <Link href="/" className="text-gray-300 hover:text-white transition-colors">
-                  ホーム
+                <Link href={base === '' ? '/' : base} className="text-gray-300 hover:text-white transition-colors">
+                  {isEnglish ? 'Home' : 'ホーム'}
                 </Link>
               </li>
               <li>
-                <Link href="/works" className="text-gray-300 hover:text-white transition-colors">
-                  作品
+                <Link href={`${base}/works`} className="text-gray-300 hover:text-white transition-colors">
+                  {isEnglish ? 'Works' : '作品'}
                 </Link>
               </li>
               <li>
-                <Link href="/news" className="text-gray-300 hover:text-white transition-colors">
-                  ニュース
+                <Link href={`${base}/news`} className="text-gray-300 hover:text-white transition-colors">
+                  {isEnglish ? 'News' : 'ニュース'}
                 </Link>
               </li>
               <li>
-                <Link href="/about" className="text-gray-300 hover:text-white transition-colors">
-                  プロフィール
+                <Link href={`${base}/about`} className="text-gray-300 hover:text-white transition-colors">
+                  {isEnglish ? 'Profile' : 'プロフィール'}
                 </Link>
               </li>
               <li>
-                <Link href="/contact" className="text-gray-300 hover:text-white transition-colors">
-                  お問い合わせ
+                <Link href={`${base}/contact`} className="text-gray-300 hover:text-white transition-colors">
+                  {isEnglish ? 'Contact' : 'お問い合わせ'}
                 </Link>
               </li>
               <li>
-                <Link href="/en" className="text-gray-300 hover:text-white transition-colors">
-                  EN
+                <Link href={isEnglish ? '/' : '/en'} className="text-gray-300 hover:text-white transition-colors">
+                  {isEnglish ? 'JP' : 'EN'}
                 </Link>
               </li>
             </ul>
@@ -45,7 +49,7 @@ const Footer = () => {
 
           {/* Social Links */}
           <div>
-            <h3 className="text-xl font-bold mb-4">ソーシャル</h3>
+          <h3 className="text-xl font-bold mb-4">{isEnglish ? 'Social' : 'ソーシャル'}</h3>
             <ul className="space-y-2">
               <li>
                 <Link
@@ -95,8 +99,9 @@ const Footer = () => {
           <div>
             <h3 className="text-xl font-bold mb-4">MARU</h3>
             <p className="text-gray-300">
-              シナリオライター。UZUにて作品を公開中。
-              SF、ミステリーなど、様々なジャンルの作品を手がけています。
+              {isEnglish
+                ? 'Scenario writer publishing works on UZU. Handles various genres including sci-fi and mystery.'
+                : 'シナリオライター。UZUにて作品を公開中。SF、ミステリーなど、様々なジャンルの作品を手がけています。'}
             </p>
           </div>
         </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,40 +1,44 @@
 "use client"
 
 import { useState } from "react"
+import { usePathname } from "next/navigation"
 import Link from "next/link"
 import { Menu, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const pathname = usePathname()
+  const isEnglish = pathname.startsWith("/en")
+  const base = isEnglish ? "/en" : ""
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-zinc-800">
       <div className="container mx-auto px-4">
         <div className="flex justify-between items-center h-16">
-          <Link href="/" className="text-2xl font-bold tracking-wider text-white">
+          <Link href={isEnglish ? "/en" : "/"} className="text-2xl font-bold tracking-wider text-white">
             MARU
           </Link>
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-6">
-            <Link href="/" className="text-white hover:text-cyan-400 transition-colors">
-              ホーム
+            <Link href={base === '' ? '/' : base} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? "Home" : "ホーム"}
             </Link>
-            <Link href="/works" className="text-white hover:text-cyan-400 transition-colors">
-              作品
+            <Link href={`${base}/works`} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? "Works" : "作品"}
             </Link>
-            <Link href="/news" className="text-white hover:text-cyan-400 transition-colors">
-              ニュース
+            <Link href={`${base}/news`} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? "News" : "ニュース"}
             </Link>
-            <Link href="/about" className="text-white hover:text-cyan-400 transition-colors">
-              プロフィール
+            <Link href={`${base}/about`} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? "Profile" : "プロフィール"}
             </Link>
-            <Link href="/contact" className="text-white hover:text-cyan-400 transition-colors">
-              お問い合わせ
+            <Link href={`${base}/contact`} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? "Contact" : "お問い合わせ"}
             </Link>
-            <Link href="/en" className="text-white hover:text-cyan-400 transition-colors">
-              EN
+            <Link href={isEnglish ? "/" : "/en"} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? "JP" : "EN"}
             </Link>
           </nav>
 
@@ -55,46 +59,46 @@ export default function Header() {
         <div className="md:hidden fixed inset-x-0 top-16 bottom-0 z-40 bg-black border-t border-zinc-800 overflow-y-auto">
           <nav className="flex flex-col py-4 px-4">
             <Link
-              href="/"
+              href={base === '' ? '/' : base}
               className="py-3 text-white hover:text-cyan-400 transition-colors"
               onClick={() => setIsMenuOpen(false)}
             >
-              ホーム
+              {isEnglish ? "Home" : "ホーム"}
             </Link>
             <Link
-              href="/works"
+              href={`${base}/works`}
               className="py-3 text-white hover:text-cyan-400 transition-colors"
               onClick={() => setIsMenuOpen(false)}
             >
-              作品
+              {isEnglish ? "Works" : "作品"}
             </Link>
             <Link
-              href="/news"
+              href={`${base}/news`}
               className="py-3 text-white hover:text-cyan-400 transition-colors"
               onClick={() => setIsMenuOpen(false)}
             >
-              ニュース
+              {isEnglish ? "News" : "ニュース"}
             </Link>
             <Link
-              href="/about"
+              href={`${base}/about`}
               className="py-3 text-white hover:text-cyan-400 transition-colors"
               onClick={() => setIsMenuOpen(false)}
             >
-              プロフィール
+              {isEnglish ? "Profile" : "プロフィール"}
             </Link>
             <Link
-              href="/contact"
+              href={`${base}/contact`}
               className="py-3 text-white hover:text-cyan-400 transition-colors"
               onClick={() => setIsMenuOpen(false)}
             >
-              お問い合わせ
+              {isEnglish ? "Contact" : "お問い合わせ"}
             </Link>
             <Link
-              href="/en"
+              href={isEnglish ? "/" : "/en"}
               className="py-3 text-white hover:text-cyan-400 transition-colors"
               onClick={() => setIsMenuOpen(false)}
             >
-              EN
+              {isEnglish ? "JP" : "EN"}
             </Link>
           </nav>
         </div>


### PR DESCRIPTION
## Summary
- add simplified English versions of About, Works, News and Contact pages
- update header and footer links to keep the chosen language
- expose CONTACT_EMAIL in `.env.example`

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a07f89488322b071f84f1d5f94a8