### PR TITLE
Add theme toggle to header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { usePathname } from "next/navigation"
 import Link from "next/link"
 import { Menu, X } from "lucide-react"
+import ThemeToggle from "./theme-toggle"
 import { Button } from "@/components/ui/button"
 
 export default function Header() {
@@ -40,6 +41,7 @@ export default function Header() {
             <Link href={isEnglish ? "/" : "/en"} className="text-white hover:text-cyan-400 transition-colors">
               {isEnglish ? "JP" : "EN"}
             </Link>
+            <ThemeToggle />
           </nav>
 
           {/* Mobile Menu Button */}
@@ -100,6 +102,7 @@ export default function Header() {
             >
               {isEnglish ? "JP" : "EN"}
             </Link>
+            <ThemeToggle />
           </nav>
         </div>
       )}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Moon, Sun } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function ThemeToggle() {
+  const { theme, resolvedTheme, setTheme } = useTheme()
+  const currentTheme = theme === "system" ? resolvedTheme : theme
+  const toggleTheme = () => {
+    const nextTheme = currentTheme === "light" ? "dark" : "light"
+    setTheme(nextTheme)
+  }
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} className="text-white">
+      {currentTheme === "light" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a ThemeToggle component
- include ThemeToggle in desktop and mobile navigation

## Testing
- `pnpm test`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_6852ac5f2bb08322988a6d40ae801334