### PR TITLE
Fix footer component and env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ pnpm install
 ## Configuration
 
 Copy `.env.example` to `.env` and fill in the required values.
-The only environment variable currently required is the Gmail application password
-used for sending emails from the contact form:
+The contact form requires two environment variables:
+
+* `GMAIL_APP_PASSWORD` – your Gmail application password
+* `CONTACT_EMAIL` – the Gmail address used by the contact form
+
+Set both variables in `.env` before running the application:
 
 ```bash
 cp .env.example .env
-# Edit .env and set GMAIL_APP_PASSWORD
+# Edit .env and set GMAIL_APP_PASSWORD and CONTACT_EMAIL
 ```
 
 ## Development server

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Link from 'next/link'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'


### PR DESCRIPTION
## Summary
- mark `Footer` as a client component so `usePathname` works
- document both required environment variables for the contact form

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6852b0e6d2a48322bdedc36cde2617ba