### PR TITLE
Fix white screen when switching language

### DIFF
--- a/src/app/en/layout.tsx
+++ b/src/app/en/layout.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
 import "../globals.css"
 import { ThemeProvider } from "next-themes"
 import Header from "../../components/header"
 import Footer from "../../components/footer"
 import React from "react"
-
-const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   metadataBase: new URL('http://localhost:3000'),
@@ -26,16 +23,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-          <div className="flex flex-col min-h-screen">
-            <Header />
-            <main className="pt-16 flex-grow">{children}</main>
-            <Footer />
-          </div>
-        </ThemeProvider>
-      </body>
-    </html>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="pt-16 flex-grow">{children}</main>
+        <Footer />
+      </div>
+    </ThemeProvider>
   )
 }


### PR DESCRIPTION
## Summary
- remove extra `<html>`/`<body>` tags from `/en` layout
- keep existing provider wrapper for English pages

## Testing
- `pnpm test`
- `pnpm lint` *(fails: react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_6852d8e1a36c8322b0ce31313696eb99