### PR TITLE
Reorder nav links

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -22,6 +22,11 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
+                <Link href={`${base}/about`} className="text-gray-300 hover:text-white transition-colors">
+                  {isEnglish ? 'Profile' : 'プロフィール'}
+                </Link>
+              </li>
+              <li>
                 <Link href={`${base}/works`} className="text-gray-300 hover:text-white transition-colors">
                   {isEnglish ? 'Works' : '作品'}
                 </Link>
@@ -29,11 +34,6 @@ const Footer = () => {
               <li>
                 <Link href={`${base}/news`} className="text-gray-300 hover:text-white transition-colors">
                   {isEnglish ? 'News' : 'ニュース'}
-                </Link>
-              </li>
-              <li>
-                <Link href={`${base}/about`} className="text-gray-300 hover:text-white transition-colors">
-                  {isEnglish ? 'Profile' : 'プロフィール'}
                 </Link>
               </li>
               <li>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -25,14 +25,14 @@ export default function Header() {
             <Link href={base === '' ? '/' : base} className="text-white hover:text-cyan-400 transition-colors">
               {isEnglish ? "Home" : "ホーム"}
             </Link>
+            <Link href={`${base}/about`} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? "Profile" : "プロフィール"}
+            </Link>
             <Link href={`${base}/works`} className="text-white hover:text-cyan-400 transition-colors">
               {isEnglish ? "Works" : "作品"}
             </Link>
             <Link href={`${base}/news`} className="text-white hover:text-cyan-400 transition-colors">
               {isEnglish ? "News" : "ニュース"}
-            </Link>
-            <Link href={`${base}/about`} className="text-white hover:text-cyan-400 transition-colors">
-              {isEnglish ? "Profile" : "プロフィール"}
             </Link>
             <Link href={`${base}/contact`} className="text-white hover:text-cyan-400 transition-colors">
               {isEnglish ? "Contact" : "お問い合わせ"}
@@ -66,6 +66,13 @@ export default function Header() {
               {isEnglish ? "Home" : "ホーム"}
             </Link>
             <Link
+              href={`${base}/about`}
+              className="py-3 text-white hover:text-cyan-400 transition-colors"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              {isEnglish ? "Profile" : "プロフィール"}
+            </Link>
+            <Link
               href={`${base}/works`}
               className="py-3 text-white hover:text-cyan-400 transition-colors"
               onClick={() => setIsMenuOpen(false)}
@@ -78,13 +85,6 @@ export default function Header() {
               onClick={() => setIsMenuOpen(false)}
             >
               {isEnglish ? "News" : "ニュース"}
-            </Link>
-            <Link
-              href={`${base}/about`}
-              className="py-3 text-white hover:text-cyan-400 transition-colors"
-              onClick={() => setIsMenuOpen(false)}
-            >
-              {isEnglish ? "Profile" : "プロフィール"}
             </Link>
             <Link
               href={`${base}/contact`}


### PR DESCRIPTION
## Summary
- reorder navigation links in header and footer so the order is: Home, Profile, Works, News, Contact, EN/JP

## Testing
- `pnpm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852daca3aa883228d44973a0517451d