### PR TITLE
Improve keyword coverage for search engines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ GMAIL_APP_PASSWORD=xnglwckdxipdktto
 
 # Email account used by the contact form API
 CONTACT_EMAIL=maruoka@sally-inc.jp
+
+# Base URL of the website used for SEO metadata
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ pnpm install
 ## Configuration
 
 Copy `.env.example` to `.env` and fill in the required values.
-The contact form requires two environment variables:
+The project requires several environment variables:
 
 * `GMAIL_APP_PASSWORD` – your Gmail application password
 * `CONTACT_EMAIL` – the Gmail address used by the contact form
+* `NEXT_PUBLIC_SITE_URL` – the base URL of the website used for SEO metadata
 
 Set both variables in `.env` before running the application:
 
 ```bash
 cp .env.example .env
-# Edit .env and set GMAIL_APP_PASSWORD and CONTACT_EMAIL
+# Edit .env and set GMAIL_APP_PASSWORD, CONTACT_EMAIL and NEXT_PUBLIC_SITE_URL
 ```
 
 ## Development server

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,17 @@
 import Link from "next/link"
 import Image from "next/image"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "プロフィール - MARU",
+  description: "マーダーミステリー・マダミス制作サークルMARUのプロフィールページです。",
+  keywords: [
+    "MARU",
+    "マーダーミステリー",
+    "マーダーミステリーアプリ",
+    "UZU",
+  ],
+}
 
 export default function AboutPage() {
   return (

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,18 @@
 "use client"
 
 import type React from "react"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "お問い合わせ - MARU",
+  description: "マーダーミステリー・マダミス制作サークルMARUへのお問い合わせフォームです。",
+  keywords: [
+    "MARU",
+    "マーダーミステリー",
+    "マーダーミステリーアプリ",
+    "UZU",
+  ],
+}
 
 import { useState } from "react"
 import { Button } from "@/components/ui/button"

--- a/src/app/en/about/page.tsx
+++ b/src/app/en/about/page.tsx
@@ -1,5 +1,7 @@
 export const metadata = {
-  title: 'About MARU'
+  title: 'About MARU',
+  description: 'Learn more about MARU, creator of unique murder mystery (madamis) scenarios.',
+  keywords: ['MARU', 'murder mystery', 'murder mystery app', 'UZU']
 }
 
 export default function EnglishAbout() {

--- a/src/app/en/contact/page.tsx
+++ b/src/app/en/contact/page.tsx
@@ -1,6 +1,13 @@
 "use client"
 
 import { useState } from 'react'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Contact - MARU',
+  description: 'Get in touch with MARU, the murder mystery (madamis) writer, using the contact form.',
+  keywords: ['MARU', 'murder mystery', 'murder mystery app', 'UZU']
+}
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'

--- a/src/app/en/layout.tsx
+++ b/src/app/en/layout.tsx
@@ -6,7 +6,7 @@ import Footer from "../../components/footer"
 import React from "react"
 
 export const metadata: Metadata = {
-  metadataBase: new URL('http://localhost:3000'),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'),
   title: {
     default: "MARU",
     template: "MARU",
@@ -14,7 +14,46 @@ export const metadata: Metadata = {
   icons: {
     icon: "/images/maru-icon.png",
   },
-  description: null,
+  description: "Official website of MARU, a creator of murder mystery scenarios.",
+  keywords: [
+    "murder mystery",
+    "madamis",
+    "murder mystery app",
+    "UZU",
+    "UZU app",
+    "MARU",
+    "SHADOW CODE",
+    "Not a Conspiracy!",
+    "Instant HO",
+    "JILVAIN",
+    "Soul Roar-Konkon-",
+    "Proof of Translucent Blue",
+    "NURUGA -Second Week Excess-",
+    "Re:CALL",
+  ],
+  openGraph: {
+    type: "website",
+    url: process.env.NEXT_PUBLIC_SITE_URL ? `${process.env.NEXT_PUBLIC_SITE_URL}/en` : 'http://localhost:3000/en',
+    title: "MARU",
+    description: "Official website of MARU, a creator of murder mystery scenarios.",
+    siteName: "MARU",
+    images: [
+      {
+        url: "/images/maru-icon.png",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary",
+    title: "MARU",
+    description: "Official website of MARU, a creator of murder mystery scenarios.",
+    images: [
+      "/images/maru-icon.png",
+    ],
+  },
+  alternates: {
+    canonical: '/en',
+  },
   viewport: {
     width: "device-width",
     initialScale: 1,

--- a/src/app/en/news/page.tsx
+++ b/src/app/en/news/page.tsx
@@ -1,4 +1,8 @@
-export const metadata = { title: 'News - MARU' }
+export const metadata = {
+  title: 'News - MARU',
+  description: 'Latest updates about MARU, a creator of murder mystery (madamis) scenarios.',
+  keywords: ['MARU', 'murder mystery', 'murder mystery app', 'UZU']
+}
 
 interface NewsItem {
   title: string

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -1,5 +1,12 @@
 export const metadata = {
-  title: "MARU - Murder Mystery Writer"
+  title: "MARU - Murder Mystery Writer",
+  description: "Official website of MARU, a Japanese murder mystery (madamis) writer.",
+  keywords: [
+    "murder mystery",
+    "murder mystery app",
+    "UZU",
+    "MARU",
+  ]
 }
 
 export default function EnglishHome() {

--- a/src/app/en/works/inbou/page.tsx
+++ b/src/app/en/works/inbou/page.tsx
@@ -4,6 +4,20 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Not a Conspiracy! - MARU",
+  description: "Details for the comedy mystery 'Not a Conspiracy!' available on the UZU app.",
+  keywords: [
+    "Not a Conspiracy!",
+    "murder mystery",
+    "madamis",
+    "murder mystery app",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function InbouPage() {
   return (

--- a/src/app/en/works/jilvain/page.tsx
+++ b/src/app/en/works/jilvain/page.tsx
@@ -4,6 +4,20 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "JILVAIN - MARU",
+  description: "Details for the fantasy mystery 'JILVAIN' available on the UZU app.",
+  keywords: [
+    "JILVAIN",
+    "murder mystery",
+    "madamis",
+    "murder mystery app",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function JilvainPage() {
   return (

--- a/src/app/en/works/page.tsx
+++ b/src/app/en/works/page.tsx
@@ -1,5 +1,15 @@
 export const metadata = {
-  title: 'Works - MARU'
+  title: 'Works - MARU',
+  description: 'A collection of murder mystery (madamis) scenarios available on the UZU app.',
+  keywords: [
+    'SHADOW CODE',
+    'Not a Conspiracy!',
+    'Instant HO',
+    'JILVAIN',
+    'murder mystery app',
+    'UZU',
+    'MARU',
+  ]
 }
 
 import Link from 'next/link'

--- a/src/app/en/works/shadow-code/page.tsx
+++ b/src/app/en/works/shadow-code/page.tsx
@@ -4,6 +4,20 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "SHADOW CODE - MARU",
+  description: "Details for the murder mystery 'SHADOW CODE' available on the UZU app.",
+  keywords: [
+    "SHADOW CODE",
+    "murder mystery",
+    "madamis",
+    "murder mystery app",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function ShadowCodePage() {
   return (

--- a/src/app/en/works/sokusei-ho/page.tsx
+++ b/src/app/en/works/sokusei-ho/page.tsx
@@ -4,6 +4,20 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Instant HO - MARU",
+  description: "Details for the playful mystery 'Instant HO' available on the UZU app.",
+  keywords: [
+    "Instant HO",
+    "murder mystery",
+    "madamis",
+    "murder mystery app",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function SokuseiHoPage() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,11 +5,12 @@ import { ThemeProvider } from "next-themes";
 import Header from "../components/header";
 import Footer from "../components/footer";
 import React from "react";
+import Script from "next/script";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('http://localhost:3000'),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'),
   title: {
     default: "MARU",
     template: "MARU",
@@ -17,7 +18,47 @@ export const metadata: Metadata = {
   icons: {
     icon: "/images/maru-icon.png", // または .png でも可
   },
-  description: null,
+  description: "マーダーミステリー・マダミス制作サークルMARUの公式サイトです。",
+  keywords: [
+    "マーダーミステリー",
+    "マダミス",
+    "マーダーミステリーアプリ",
+    "UZU",
+    "UZUアプリ",
+    "MARU",
+    "SHADOW CODE",
+    "陰謀論者じゃないもん！",
+    "即席HO",
+    "JILVAIN",
+    "魂吼-コンコン-",
+    "透きとおる青の証明",
+    "NURUGA-2週目の蛇足-",
+    "Re:CALL（リコール）",
+    "シナリオ",
+  ],
+  openGraph: {
+    type: "website",
+    url: process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000',
+    title: "MARU",
+    description: "マーダーミステリー・マダミス制作サークルMARUの公式サイトです。",
+    siteName: "MARU",
+    images: [
+      {
+        url: "/images/maru-icon.png",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary",
+    title: "MARU",
+    description: "マーダーミステリー・マダミス制作サークルMARUの公式サイトです。",
+    images: [
+      "/images/maru-icon.png",
+    ],
+  },
+  alternates: {
+    canonical: '/',
+  },
   viewport: {
     width: "device-width",
     initialScale: 1,
@@ -31,6 +72,23 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
+      <head>
+        <Script
+          id="ld-json"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Organization',
+              name: 'MARU',
+              url: process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000',
+              sameAs: ['https://x.com/mok4shiro'],
+              keywords:
+                'マーダーミステリー, マダミス, マーダーミステリーアプリ, UZU, UZUアプリ, MARU, SHADOW CODE, 陰謀論者じゃないもん！, 即席HO, JILVAIN, 魂吼-コンコン-, 透きとおる青の証明, NURUGA-2週目の蛇足-, Re:CALL（リコール）',
+            }),
+          }}
+        />
+      </head>
       <body className={inter.className}>
         <ThemeProvider
           attribute="class"

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,4 +1,11 @@
 import TwitterFeed from "@/components/twitter-feed"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "ニュース - MARU",
+  description: "マーダーミステリー・マダミス制作サークルMARUに関する最新情報を掲載しています。",
+  keywords: ["MARU", "マーダーミステリー", "マーダーミステリーアプリ", "UZU"],
+}
 
 interface NewsItem {
   title: string

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,13 @@ import type { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: "MARU",
+  description: "マーダーミステリー・マダミス制作サークルMARUの公式サイトです。",
+  keywords: [
+    "マーダーミステリー",
+    "マーダーミステリーアプリ",
+    "UZU",
+    "MARU",
+  ],
 }
 
 export default function Home() {

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -1,0 +1,5 @@
+export function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  const content = `User-agent: *\nAllow: /\nSitemap: ${baseUrl}/sitemap.xml`
+  return new Response(content, { headers: { 'Content-Type': 'text/plain' } })
+}

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,0 +1,10 @@
+const pages = ['', 'about', 'works', 'news', 'contact', 'en', 'en/about', 'en/works', 'en/news', 'en/contact']
+
+export function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  const urls = pages
+    .map((page) => `<url><loc>${baseUrl}/${page}</loc></url>`) 
+    .join('')
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`
+  return new Response(xml, { headers: { 'Content-Type': 'application/xml' } })
+}

--- a/src/app/works/inbou/page.tsx
+++ b/src/app/works/inbou/page.tsx
@@ -4,6 +4,21 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "陰謀論者じゃないもん！ - MARU",
+  description:
+    "マーダーミステリーアプリUZUで遊べる『陰謀論者じゃないもん！』の詳細ページです。",
+  keywords: [
+    "陰謀論者じゃないもん！",
+    "マーダーミステリー",
+    "マダミス",
+    "マーダーミステリーアプリ",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function InbouPage() {
   return (

--- a/src/app/works/jilvain/page.tsx
+++ b/src/app/works/jilvain/page.tsx
@@ -4,6 +4,20 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "JILVAIN - MARU",
+  description: "UZUで遊べるマーダーミステリー『JILVAIN』の詳細ページです。",
+  keywords: [
+    "JILVAIN",
+    "マーダーミステリー",
+    "マダミス",
+    "マーダーミステリーアプリ",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function JilvainPage() {
   return (

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -3,6 +3,21 @@ import Image from "next/image"
 import { ChevronRight, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "作品一覧 - MARU",
+  description: "MARUが制作したマーダーミステリー・マダミス作品の一覧です。",
+  keywords: [
+    "SHADOW CODE",
+    "陰謀論者じゃないもん！",
+    "即席HO",
+    "JILVAIN",
+    "マーダーミステリーアプリ",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function WorksPage() {
   return (

--- a/src/app/works/shadow-code/page.tsx
+++ b/src/app/works/shadow-code/page.tsx
@@ -4,6 +4,20 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "SHADOW CODE - MARU",
+  description: "UZUで遊べるマーダーミステリー『SHADOW CODE』の詳細ページです。",
+  keywords: [
+    "SHADOW CODE",
+    "マーダーミステリー",
+    "マダミス",
+    "マーダーミステリーアプリ",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function ShadowCodePage() {
   return (

--- a/src/app/works/sokusei-ho/page.tsx
+++ b/src/app/works/sokusei-ho/page.tsx
@@ -4,6 +4,20 @@ import { ArrowLeft, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "即席HO - MARU",
+  description: "UZUで遊べるマーダーミステリー『即席HO』の詳細ページです。",
+  keywords: [
+    "即席HO",
+    "マーダーミステリー",
+    "マダミス",
+    "マーダーミステリーアプリ",
+    "UZU",
+    "MARU",
+  ],
+}
 
 export default function SokuseiHoPage() {
   return (


### PR DESCRIPTION
## Summary
- extend global SEO keywords with UZU and individual work titles
- add keyword metadata to each works detail page (JP and EN)
- provide keywords for home, about, news, and contact pages
- embed keywords in organization structured data

## Testing
- `pnpm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6857810c774083229ab3e6c1791c24b1