### PR TITLE
Fix language switch blank screen

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import Header from "../components/header";
 import Footer from "../components/footer";
+import LanguageSetter from "../components/language-setter";
 import React from "react";
 import Script from "next/script";
 
@@ -96,6 +97,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <LanguageSetter />
           <div className="flex flex-col min-h-screen">
             <Header />
             <main className="pt-16 flex-grow">

--- a/src/components/language-setter.tsx
+++ b/src/components/language-setter.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+export default function LanguageSetter() {
+  const pathname = usePathname();
+  useEffect(() => {
+    const lang = pathname.startsWith("/en") ? "en" : "ja";
+    if (document.documentElement.lang !== lang) {
+      document.documentElement.lang = lang;
+    }
+  }, [pathname]);
+  return null;
+}


### PR DESCRIPTION
## Summary
- add LanguageSetter client component to update `<html lang>`
- use LanguageSetter in main layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68579e052ee08322a6a0542e75f1162d