### PR TITLE
Update profile with Hanagara release

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -74,10 +74,13 @@ export default function AboutPage() {
                 UZUアプリでマーダーミステリーを制作しているMARUです。
                 プレイヤーが没入できる世界観と、今までにないギミック体験が特徴です。
               </p>
-              <p className="text-zinc-300">
+              <p className="text-zinc-300 mb-4">
                 「SHADOW CODE」「JILVAIN」などの作品を手がけています。
                 UZUならではの機能を活かした、独自のギミックを取り入れたシナリオ作りを心がけています。
                 また、他作品のUZUへの移植作業や実装も行なっています。
+              </p>
+              <p className="text-zinc-300">
+                2025年7月18日に最新作「花枯らの檻」をリリースしました。
               </p>
             </div>
 
@@ -106,6 +109,12 @@ export default function AboutPage() {
                   <span className="w-32 text-gray-300">2025/02/18</span>
                   <Link href="/works/jilvain" className="text-gray-300 hover:text-white">
                     JILVAIN
+                  </Link>
+                </li>
+                <li className="flex items-center">
+                  <span className="w-32 text-gray-300">2025/07/18</span>
+                  <Link href="/works/hanagara" className="text-gray-300 hover:text-white">
+                    花枯らの檻
                   </Link>
                 </li>
               </ul>

--- a/src/app/en/about/page.tsx
+++ b/src/app/en/about/page.tsx
@@ -58,6 +58,9 @@ export default function EnglishAbout() {
                 <p>
                   Known for titles like &quot;SHADOW CODE&quot; and &quot;JILVAIN&quot;.
                 </p>
+                <p>
+                  The latest work &quot;Hanagara no Ori&quot; was released on July 18, 2025.
+                </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- mention that Hanagara no Ori was released on July 18, 2025 in the profile
- list the new work in the works section
- add the same note to the English profile

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68667596a5288322b496b16d7ed4480c