### PR TITLE
Add Hanagara no Ori to hero slider

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,12 +82,16 @@
 
 @keyframes heroSlideBackground {
   0%,
-  45% {
+  30% {
     background-image: url("/images/shadow-code-cover.png");
   }
-  50%,
-  95% {
+  35%,
+  65% {
     background-image: url("/images/jilvain-cover.png");
+  }
+  70%,
+  95% {
+    background-image: url("/images/hanagara_KV.jpg");
   }
   100% {
     background-image: url("/images/shadow-code-cover.png");


### PR DESCRIPTION
## Summary
- include `hanagara_KV.jpg` in the hero slider rotation so the front page cycles SHADOW CODE, JILVAIN and 花枯らの檻

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686677edaf048322b63f9b3e32425384