### PR TITLE
Create Apple-style mobile header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation"
 import Link from "next/link"
 import MobileNav from "./mobile-nav"
+import { Search } from "lucide-react"
 
 export default function Header() {
   const pathname = usePathname()
@@ -12,38 +13,48 @@ export default function Header() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-md border-b border-zinc-800">
       <div className="container mx-auto px-4">
-        <div className="flex justify-between items-center h-16">
-          <Link href={isEnglish ? "/en" : "/"} className="text-2xl font-bold tracking-wider text-white">
+        <div className="relative flex items-center justify-between h-16">
+          {/* Mobile Menu */}
+          <div className="md:hidden">
+            <MobileNav />
+          </div>
+
+          {/* Site Title */}
+          <Link
+            href={isEnglish ? "/en" : "/"}
+            className="absolute left-1/2 -translate-x-1/2 text-2xl font-bold tracking-wider text-white md:static md:translate-x-0"
+          >
             MARU
           </Link>
 
           {/* Desktop Navigation */}
-          <nav className="hidden md:flex items-center space-x-6">
+          <nav className="hidden md:flex items-center ml-auto space-x-6">
             <Link href={base === '' ? '/' : base} className="text-white hover:text-cyan-400 transition-colors">
-              {isEnglish ? "Home" : "ホーム"}
+              {isEnglish ? 'Home' : 'ホーム'}
             </Link>
             <Link href={`${base}/about`} className="text-white hover:text-cyan-400 transition-colors">
-              {isEnglish ? "Profile" : "プロフィール"}
+              {isEnglish ? 'Profile' : 'プロフィール'}
             </Link>
             <Link href={`${base}/works`} className="text-white hover:text-cyan-400 transition-colors">
-              {isEnglish ? "Works" : "作品"}
+              {isEnglish ? 'Works' : '作品'}
             </Link>
             <Link href={`${base}/news`} className="text-white hover:text-cyan-400 transition-colors">
-              {isEnglish ? "News" : "ニュース"}
+              {isEnglish ? 'News' : 'ニュース'}
             </Link>
             <Link href={`${base}/contact`} className="text-white hover:text-cyan-400 transition-colors">
-              {isEnglish ? "Contact" : "お問い合わせ"}
+              {isEnglish ? 'Contact' : 'お問い合わせ'}
             </Link>
-            <Link href={isEnglish ? "/" : "/en"} className="text-white hover:text-cyan-400 transition-colors">
-              {isEnglish ? "JP" : "EN"}
+            <Link href={isEnglish ? '/' : '/en'} className="text-white hover:text-cyan-400 transition-colors">
+              {isEnglish ? 'JP' : 'EN'}
             </Link>
           </nav>
 
-          <MobileNav />
+          {/* Mobile Search Icon for alignment */}
+          <button className="md:hidden" aria-label="search" type="button">
+            <Search className="h-6 w-6 text-white" />
+          </button>
         </div>
       </div>
-
-
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- improve responsive header layout for smartphone screens
- center title text and include a search icon

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686698a79f7883229b6e23ea4e36a11c