### PR TITLE
Remove mobile search icon

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,7 +3,6 @@
 import { usePathname } from "next/navigation"
 import Link from "next/link"
 import MobileNav from "./mobile-nav"
-import { Search } from "lucide-react"
 
 export default function Header() {
   const pathname = usePathname()
@@ -49,10 +48,6 @@ export default function Header() {
             </Link>
           </nav>
 
-          {/* Mobile Search Icon for alignment */}
-          <button className="md:hidden" aria-label="search" type="button">
-            <Search className="h-6 w-6 text-white" />
-          </button>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- remove search icon from the mobile header since it's not required

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686e37a8435c83229f87a0bc1d31b4b0